### PR TITLE
Code cleanup

### DIFF
--- a/client/catalog/src/app/datatypes/DatatypeDetail.svelte
+++ b/client/catalog/src/app/datatypes/DatatypeDetail.svelte
@@ -25,6 +25,7 @@ var dt = {
 	validator : {
 		id: "",
 		runtime : "",
+		functionSignature : 1
 		}
 
 };

--- a/client/catalog/src/app/datatypes/DatatypeNew.svelte
+++ b/client/catalog/src/app/datatypes/DatatypeNew.svelte
@@ -34,7 +34,7 @@ const newDatatypeOp = {
 			name : "",
 			runtime: 2,
 			code: "",
-			functionSignature: 0,
+			functionSignature: 1
 		}
 	}
 }

--- a/client/catalog/src/app/rpc/RPCDetail.svelte
+++ b/client/catalog/src/app/rpc/RPCDetail.svelte
@@ -22,7 +22,7 @@ var rpc = {
 		id : "",
 		code : "",
 		runtime : 2,
-		functionSignature : 1
+		functionSignature : 2
 	}
 }
 

--- a/client/catalog/src/app/rpc/RPCNew.svelte
+++ b/client/catalog/src/app/rpc/RPCNew.svelte
@@ -30,7 +30,7 @@ const newRPCOp = {
 			name : "",
 			runtime: 2,
 			code: "",
-			functionSignature: 1,
+			functionSignature: 2
 		}
 	}
 }

--- a/internal/db/code.go
+++ b/internal/db/code.go
@@ -18,7 +18,8 @@ type Code struct {
 type FunctionSignature int64
 
 const (
-	FromJSON FunctionSignature = iota
+	InvalidFunctionSignature FunctionSignature = iota
+	FromJSON
 	RPC
 )
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -81,8 +81,9 @@ type RWTx interface {
 
 	// these are good, i think
 	Insert(Record) error
-	Update(oldRec, newRec Record) error
 	Connect(from, to Record, fromRel Relationship) error
+	Update(oldRec, newRec Record) error
+	Delete(Record) error
 
 	Commit() error
 }
@@ -192,6 +193,12 @@ func (tx *holdTx) Connect(left, right Record, rel Relationship) error {
 	h1 := tx.h.Insert(left)
 	h2 := h1.Insert(right)
 	tx.h = h2
+	return nil
+}
+
+func (tx *holdTx) Delete(rec Record) error {
+	tx.ensureWrite()
+	tx.h = tx.h.Delete(rec)
 	return nil
 }
 

--- a/internal/db/metamodel.go
+++ b/internal/db/metamodel.go
@@ -168,7 +168,7 @@ var ValidatorCode = Relationship{
 
 var boolValidator = Code{
 	ID:                uuid.MustParse("8e806967-c462-47af-8756-48674537a909"),
-	Name:              "boolValidator",
+	Name:              "bool",
 	Runtime:           Golang,
 	Function:          datatypes.BoolFromJSON,
 	executor:          &bootstrapCodeExecutor{},
@@ -177,7 +177,7 @@ var boolValidator = Code{
 
 var intValidator = Code{
 	ID:                uuid.MustParse("a1cf1c16-040d-482c-92ae-92d59dbad46c"),
-	Name:              "intValidator",
+	Name:              "int",
 	Runtime:           Golang,
 	Function:          datatypes.IntFromJSON,
 	executor:          &bootstrapCodeExecutor{},
@@ -186,7 +186,7 @@ var intValidator = Code{
 
 var enumValidator = Code{
 	ID:                uuid.MustParse("5c3b9da9-c592-41da-b6e2-8c8dd97186c3"),
-	Name:              "enumValidator",
+	Name:              "enum",
 	Runtime:           Golang,
 	Function:          datatypes.EnumFromJSON,
 	executor:          &bootstrapCodeExecutor{},
@@ -195,7 +195,7 @@ var enumValidator = Code{
 
 var stringValidator = Code{
 	ID:                uuid.MustParse("aaeccd14-e69f-4561-91ef-5a8a75b0b498"),
-	Name:              "stringValidator",
+	Name:              "string",
 	Runtime:           Golang,
 	Function:          datatypes.StringFromJSON,
 	executor:          &bootstrapCodeExecutor{},
@@ -204,7 +204,7 @@ var stringValidator = Code{
 
 var textValidator = Code{
 	ID:                uuid.MustParse("9f10ac9f-afd2-423a-8857-d900a0c97563"),
-	Name:              "textValidator",
+	Name:              "text",
 	Runtime:           Golang,
 	Function:          datatypes.TextFromJSON,
 	executor:          &bootstrapCodeExecutor{},
@@ -213,7 +213,7 @@ var textValidator = Code{
 
 var uuidValidator = Code{
 	ID:                uuid.MustParse("60dfeee2-105f-428d-8c10-c4cc3557a40a"),
-	Name:              "uuidValidator",
+	Name:              "uuid",
 	Runtime:           Golang,
 	Function:          datatypes.UUIDFromJSON,
 	executor:          &bootstrapCodeExecutor{},
@@ -222,7 +222,7 @@ var uuidValidator = Code{
 
 var floatValidator = Code{
 	ID:                uuid.MustParse("83a5f999-00b0-4bc1-879a-434869cf7301"),
-	Name:              "floatValidator",
+	Name:              "float",
 	Runtime:           Golang,
 	Function:          datatypes.FloatFromJSON,
 	executor:          &bootstrapCodeExecutor{},

--- a/internal/oplog/goblog.go
+++ b/internal/oplog/goblog.go
@@ -83,6 +83,7 @@ func initGob() {
 	gob.Register(CreateOp{})
 	gob.Register(ConnectOp{})
 	gob.Register(UpdateOp{})
+	gob.Register(DeleteOp{})
 	gob.Register(TxEntry{})
 }
 

--- a/internal/rpc/models.go
+++ b/internal/rpc/models.go
@@ -40,13 +40,9 @@ var reactFormRPC = db.Code{
     attrs = FindMany("attribute", EqFK("model", rec.ID()))
     out = {}
     for attr in attrs:
-        n = str(attr.Get("name"))
+        n = str(attr.Get("name")).title()
         dt = FindOne("datatype", Eq("id", attr.GetFK("datatype")))
-        t = str(dt.Get("name"))
-        if t == "enum" or t == "int":
-            t = "integer"
-        if t == "emailAddress" or "url":
-            t = "string"
+        t = str(dt.Get("storedAs"))
         out[n] = {"type" : t, "title" : n}
     return out
 

--- a/internal/rpc/module.go
+++ b/internal/rpc/module.go
@@ -18,7 +18,7 @@ func (m Module) ProvideRoutes() []lib.Route {
 	return []lib.Route{
 		lib.Route{
 			Name:    "RPC",
-			Pattern: "/views/rpc",
+			Pattern: "/views/rpc/{name}",
 			Handler: lib.ErrorHandler(RPCHandler{db: m.db, bus: m.bus}),
 		},
 	}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -4,13 +4,13 @@ import (
 	"awans.org/aft/internal/bus"
 	"awans.org/aft/internal/db"
 	"awans.org/aft/internal/server/lib"
+	"github.com/gorilla/mux"
 	"github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 )
 
 type RPCRequest struct {
-	Name string                 `json:"name"`
 	Data map[string]interface{} `json:"data"`
 }
 
@@ -24,6 +24,8 @@ type RPCHandler struct {
 }
 
 func (rh RPCHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (err error) {
+	vars := mux.Vars(r)
+	name := vars["name"]
 	var rr RPCRequest
 	buf, _ := ioutil.ReadAll(r.Body)
 	err = jsoniter.Unmarshal(buf, &rr)
@@ -34,7 +36,7 @@ func (rh RPCHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (err erro
 	rh.bus.Publish(lib.ParseRequest{Request: rr})
 
 	rwtx := rh.db.NewRWTx()
-	RPCOut, err := eval(rr.Name, rr.Data, rwtx)
+	RPCOut, err := eval(name, rr.Data, rwtx)
 	if err != nil {
 		return
 	}

--- a/internal/runtime/core.go
+++ b/internal/runtime/core.go
@@ -4,7 +4,6 @@ import (
 	"awans.org/aft/internal/datatypes"
 	"awans.org/aft/internal/db"
 	"awans.org/aft/internal/starlark"
-	"fmt"
 )
 
 type FunctionHandle interface {
@@ -18,10 +17,8 @@ func codeToFunctionHandle(c db.Code) FunctionHandle {
 		fh = &datatypes.GoFunctionHandle{Function: c.Function}
 	case db.Starlark:
 		code := c.Code
-		if c.FunctionSignature == db.FromJSON {
-			code = fmt.Sprintf("%s\n\nresult(validator(args))", code)
-		}
-		fh = &starlark.StarlarkFunctionHandle{Code: code}
+		fs := c.FunctionSignature
+		fh = &starlark.StarlarkFunctionHandle{Code: code, FunctionSignature: fs}
 	}
 	return fh
 }

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -61,7 +61,10 @@ func Run(dblogPath string) {
 	if err != nil {
 		panic(err)
 	}
-
+	err = oplog.DBFromLog(appDB, dbLog)
+	if err != nil {
+		panic(err)
+	}
 	appDB = oplog.LoggedDB(dbLog, appDB)
 
 	bus.Publish(lib.DatabaseReady{Db: appDB})

--- a/internal/starlark/starlark.go
+++ b/internal/starlark/starlark.go
@@ -1,15 +1,17 @@
 package starlark
 
 import (
+	"awans.org/aft/internal/db"
 	"fmt"
 	"go.starlark.net/starlark"
 )
 
 type StarlarkFunctionHandle struct {
-	Code   string
-	Env    map[string]interface{}
-	result interface{}
-	err    interface{}
+	Code              string
+	FunctionSignature db.FunctionSignature
+	Env               map[string]interface{}
+	result            interface{}
+	err               interface{}
 }
 
 func (s *StarlarkFunctionHandle) Invoke(input interface{}) (interface{}, error) {
@@ -22,6 +24,9 @@ func (s *StarlarkFunctionHandle) Invoke(input interface{}) (interface{}, error) 
 		return nil, err
 	}
 
+	if s.FunctionSignature == db.FromJSON {
+		s.Code = fmt.Sprintf("%s\n\nresult(validator(args))", s.Code)
+	}
 	// Run the starlark interpreter!
 	_, err = starlark.ExecFile(&starlark.Thread{Load: nil}, "", []byte(s.Code), globals)
 


### PR DESCRIPTION
@awans been processing what to do next and I did some small clean up as therapy.

One thought – this is small potatoes really – is to create an EnumModel and a DatatypeEnum relationship so we can get Enums out on the clients. This is kind of annoying specifically for the reactForm RPC as you want to refer to enums by their string name not their integer, and that gonna introduce boilerplate with the current setup. Generally the fact that there are enums in catalog bother me.

Oh and deletes work (but ignore connections entirely) as does Exec on code records in anything that uses the DB lib (Repl and RPC for now).